### PR TITLE
GitHub action update for PyPI publishing

### DIFF
--- a/.github/workflows/publish-sdist.yml
+++ b/.github/workflows/publish-sdist.yml
@@ -23,6 +23,6 @@ jobs:
           python -m build
 
       - name: Publish distribution package to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Message from [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish):
"The `master` branch version has been sunset. Please, change the GitHub Action version you use from `master` to `release/v1`."